### PR TITLE
Add peer dependencies for express and @types/express

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
     "url": "https://github.com/nodesandbox/response-kit/issues"
   },
   "homepage": "https://github.com/nodesandbox/response-kit#readme",
-  "dependencies": {
-    "express": "^4.21.1"
+  "dependencies": {},
+  "peerDependencies": {
+    "express": "^4.21.1",
+    "@types/express": "^5.0.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.0",
     "typescript": "^5.6.3"
   },
   "files": [


### PR DESCRIPTION
### Summary

This pull request updates the `package.json` file for the `@nodesandbox/response-kit` package to include `express` and `@types/express` as peer dependencies. This change ensures that users of the package are informed of the required versions for proper functionality and compatibility with their applications.

### Changes Made

- Added `express` and `@types/express` as peer dependencies with specified version ranges to prevent compatibility issues with future updates.

### Rationale

Specifying these peer dependencies helps ensure that users install the correct versions needed for `@nodesandbox/response-kit` to work seamlessly with their Node.js (Express) applications. It also provides clear guidance on which versions have been tested and are supported.

### Additional Notes

No other changes were made to the functionality or structure of the package. Please review and merge this update to enhance the usability of the package.

Fix #1