### PR TITLE
Update README: Add peer dependency details for Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ You can install the package via npm:
 npm install @nodesandbox/response-kit
 ```
 
+### Peer Dependency
+
+Please note that this package requires `express` to function properly. You need to install `express` in your project as well:
+
+```bash
+npm install express @types/express
+```
+
 ## Usage
 
 Here's a quick example of how to use the response and error handlers in your Express application:


### PR DESCRIPTION
### Summary
This pull request updates the `README.md` file for the `@nodesandbox/response-kit` package to include information about the required peer dependency, `express`. It clarifies that users need to install `express` in their projects for the package to function correctly.

### Changes Made
- Added a **Peer Dependency** section to the Installation instructions.
- Provided installation command for `express` and its type definitions.

### Reasoning
This update aims to improve the clarity of the documentation, ensuring that users are aware of the dependency requirements before using the package, thus enhancing their overall experience with `@nodesandbox/response-kit`.

Fix #1 
